### PR TITLE
fix markdown headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 [![License](http://img.shields.io/badge/license-MIT-A31F34.svg)](https://github.com/MorganConrad/fcs)
 [![NPM Downloads](http://img.shields.io/npm/dm/fcs.svg)](https://www.npmjs.org/package/fcs)
 
-#fcs
+# fcs
 
 Javascript / node.js code to read FCS flow cytometry data.  Will read all of the HEADER, TEXT, and ANALYSIS segments into key/value pairs.  Reads raw (likely uncompensated) data as well, either into numeric arrays for further analysis, or as Strings for quickly scanning the data. 
 
-##basic usage
+## basic usage
 
 1. Get the FCS file into a Buffer
 2. Create a new FCS(theBuffer, options)
@@ -26,9 +26,9 @@ e.g. to read from a file asynchronously
    });
 ```
 
-###see fcscli.js or fcshttp.js in the examples folder for usage examples
+### see fcscli.js or fcshttp.js in the examples folder for usage examples
 
-##options (default in bold)
+## options (default in bold)
 
 * dataFormat:   'asNumber', '**asString**', 'asBoth', or 'asNone'
 * groupBy:       '**byEvent**', 'byParameter'
@@ -39,24 +39,24 @@ e.g. to read from a file asynchronously
 
 Any additional options are ignored, but will be printed under a "meta" segment in the JSON.  For example, you might want to include a date, your laboratory, etc...
 
-#api
+# api
 
-##creational
+## creational
 
-###var myFCS = new FCS(options, buffer)
+### var myFCS = new FCS(options, buffer)
 Constructor.  Both arguments are optional.
 If buffer is present it will be read, otherwise you need to call **readBuffer()** or **readStreamAsync()** later
 
-###myFCS.options(options)
+### myFCS.options(options)
 Set or add options.
 
-###myFCS.readBuffer(buffer, moreOptions)
+### myFCS.readBuffer(buffer, moreOptions)
 Read data from buffer.  moreOptions are optional.  Hopefully by now you've set them all! :-)
 
-###myFCS.readStreamAsync(readStream, moreOptions, callback)
+### myFCS.readStreamAsync(readStream, moreOptions, callback)
 Reads data asynchronously from a readStream.  moreOptions is optional.  When complete, calls `callback(err, fcs)`.
 
-###myFCS.prepareWriteableStream(callback, readableStream)
+### myFCS.prepareWriteableStream(callback, readableStream)
 The readableStream arg is optional.  Creates a writeableStream ready to parse an FCS format file.  e.g.
 
     var fws = fcs.prepareWriteableStream(callback, readableStream);
@@ -64,36 +64,36 @@ The readableStream arg is optional.  Creates a writeableStream ready to parse an
     
 When piping is complete, will call `callback(err, fcs)`.
 
-##retrieving the data
+## retrieving the data
 
-###get(segment, keywords...)
+### get(segment, keywords...)
 segment should be one of  ('text', 'analysis', or, more rarely, 'header', 'meta').  
 If no keywords are provided, returns that entire segment  
 otherwise, returns a single value, stopping at the first match to the keyword.  
 Returns null if none were found.
 
-###getText(keywords...)
+### getText(keywords...)
 Equivalent to get('text', keywords)  
   *e.g.* `text('$P3N') might return 'FL1-H'  
 
-###get$PnX(x)
+### get$PnX(x)
 Return an array of all N keywords for that P.X combination.  The 0th value will be empty.  
   *e.g.* `get$PnX('N') might return ['', 'FSC, 'SSC', 'FL1-H', ...]
 
-###getAnalysis(keyword, additionalKeywords...)
+### getAnalysis(keyword, additionalKeywords...)
 Equivalent to get('analysis', keywords)
 
-###getNumericData(oneBasedIndex)
+### getNumericData(oneBasedIndex)
 Returns an array of Numbers for the respective event or parameter, iff you requested numeric data.
 
-###getStringData(oneBasedIndex)
+### getStringData(oneBasedIndex)
 Returns an array of Strings for the respective event or parameter, iff you requested string data.
 
-###getOnly(onlys)
+### getOnly(onlys)
 Returns a subset of the JSON, based upon onlys, an array of dot delimited Strings  
   *e.g.* getOnlys(['meta','text.$P1N') would return all of meta, plus parameter 1 name
 
-##fields
+## fields
 
 ### .header
   Holds the HEADER segment (first 256 bytes).  The version is header.FCSVersion


### PR DESCRIPTION
From the [commonmark spec](http://spec.commonmark.org/0.17/):

> The opening sequence of # characters cannot be followed directly by a non-space character.