### PR TITLE
Changes to make the correct json

### DIFF
--- a/fcs.js
+++ b/fcs.js
@@ -45,7 +45,7 @@ function FCS(/* optional */ options, buffer) {
     // collect meta, header, text, and analysis
     let segmentVals = Object.keys(FCS.SEGMENT).map((key) => {
       let segmentName = FCS.SEGMENT[key];
-      return '"' + segmentName + ': "' + JSON.stringify(this[segmentName], null, 2);
+      return '"' + segmentName + '" :' + JSON.stringify(this[segmentName], null, 2);
     });
     let json = '{\n ' + segmentVals.join(',\n ');
 


### PR DESCRIPTION
When using toJSON() to create a json string, the correct json was not returned.
Specifically, the part that should have been `"meta": ` was `"meta:"`. So, I fixed the part in the code where `"` and `:` were reversed.